### PR TITLE
Allow for question writer to specify the width and height of the image

### DIFF
--- a/extras/WebWork/RserveClient.pl
+++ b/extras/WebWork/RserveClient.pl
@@ -193,12 +193,14 @@ sub rserve_start_plot {
     _rserve_warn_no_config && return unless $Rserve->{host};
     
     my $device = shift // 'png';
+    my $width = shift // 300;
+    my $height = shift // 300;
 
     die "Unsupported image type $device" unless $device =~ /^(png|pdf|jpg)$/;
     my $remote_image = (rserve_eval("tempfile(fileext='.$device')"))[0];
     
     $device =~ s/jpg/jpeg/;
-    rserve_eval("$device('$remote_image')");
+    rserve_eval("$device('$remote_image', width = $width, height = $height)");
 
     $remote_image
 }


### PR DESCRIPTION
When I'm writing questions for WeBWorK, I really like having the ability to specify the width and height for my images. I was able to get this functionality by adding a couple of additional arguments to rserve_start_plot. This should be compatible with previous versions of the macro, and will default to a width of 300 px and height of 300 px.

If are willing to accept the pull request, I would recommend a minor change to the authoring guide. Lines 15 - 17 of the current example for displaying R graphics could be updated to read 
```
$mean = random(-2, 2, .5);
$width = 300;
$height = 300;

$img = rserve_start_plot('png', $width, $height);
```
with a corresponding change to the WeBWorK code for displaying the image
```
\{ image($image_path, width=>$width, height=>$height) \}
```

Thank you for considering the pull request.